### PR TITLE
fix: scope tempMessage for error handling

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -62,9 +62,10 @@ const renderMessages = (messages) => {
 const sendMessage = async () => {
   const content = msgInput.value.trim();
   if (!content) return;
-  
+
+  let tempMessage;
   try {
-    const tempMessage = renderMessage({
+    tempMessage = renderMessage({
       sender: user,
       content: content,
       timestamp: new Date().toISOString(),
@@ -92,9 +93,11 @@ const sendMessage = async () => {
     msgInput.focus();
   } catch (error) {
     showError('فشل إرسال الرسالة: ' + error.message);
-    const statusEl = tempMessage.querySelector('.message-status');
-    if (statusEl) {
-      statusEl.innerHTML = '<i class="fas fa-times"></i> فشل الإرسال';
+    if (tempMessage) {
+      const statusEl = tempMessage.querySelector('.message-status');
+      if (statusEl) {
+        statusEl.innerHTML = '<i class="fas fa-times"></i> فشل الإرسال';
+      }
     }
   }
 };

--- a/public/js/dm.js
+++ b/public/js/dm.js
@@ -140,9 +140,10 @@ const renderDMs = (messages) => {
 const sendDM = async () => {
   const content = dmInput.value.trim();
   if (!content || !currentReceiver) return;
-  
+
+  let tempMessage;
   try {
-    const tempMessage = renderMessage({
+    tempMessage = renderMessage({
       sender: user,
       content: content,
       timestamp: new Date().toISOString(),
@@ -173,9 +174,11 @@ const sendDM = async () => {
     dmInput.focus();
   } catch (error) {
     showError('فشل إرسال الرسالة: ' + error.message);
-    const statusEl = tempMessage.querySelector('.message-status');
-    if (statusEl) {
-      statusEl.innerHTML = '<i class="fas fa-times"></i> فشل الإرسال';
+    if (tempMessage) {
+      const statusEl = tempMessage.querySelector('.message-status');
+      if (statusEl) {
+        statusEl.innerHTML = '<i class="fas fa-times"></i> فشل الإرسال';
+      }
     }
   }
 };


### PR DESCRIPTION
## Summary
- make tempMessage accessible in chat/dm send functions
- guard against undefined tempMessage in catch blocks

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687a81fef3d083238bb3760b4fb05ced