### PR TITLE
Fix missing 404 page and add coverage

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8" />
+  <title>404 - الصفحة غير موجودة</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 50px; }
+  </style>
+</head>
+<body>
+  <h1>404</h1>
+  <p>عذرًا، الصفحة غير موجودة.</p>
+</body>
+</html>

--- a/tests/404.test.js
+++ b/tests/404.test.js
@@ -1,0 +1,16 @@
+process.env.NODE_ENV = 'test';
+process.env.PORT = 0;
+const request = require('supertest');
+const { app, server } = require('../server/app');
+
+afterAll(() => {
+  server.close();
+});
+
+describe('GET unknown route', () => {
+  it('returns custom 404 page', async () => {
+    const res = await request(app).get('/does-not-exist');
+    expect(res.status).toBe(404);
+    expect(res.text).toContain('404');
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple 404 error page
- test unknown routes return the 404 page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab0c14d9483239075891bd5dedb66