### PR TITLE
Fix missing 404 page and update DB dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nexus-site",
       "version": "1.0.0",
       "dependencies": {
-        "better-sqlite3": "^8.5.1",
+        "better-sqlite3": "^12.2.0",
         "body-parser": "^2.2.0",
         "compression": "^1.8.1",
         "cors": "^2.8.5",
@@ -1766,13 +1766,17 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
-      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "better-sqlite3": "^8.5.1",
+    "better-sqlite3": "^12.2.0",
     "body-parser": "^2.2.0",
     "compression": "^1.8.1",
     "cors": "^2.8.5",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <title>404</title>
+  <style>
+    body { text-align: center; font-family: sans-serif; padding-top: 50px; }
+  </style>
+</head>
+<body>
+  <h1>الصفحة غير موجودة</h1>
+  <p>عذراً، الصفحة التي تبحث عنها غير متوفرة.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update better-sqlite3 to a version that supports modern Node
- add a 404.html page so missing routes serve a real page

## Testing
- `npm test`
- `npm start` *(fails: libnode.so.109 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab0c14d9483239075891bd5dedb66