### PR TITLE
Fix notification sound initialization

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -156,12 +156,13 @@ const updateUserStatuses = (onlineUsers) => {
   renderOnlineUsers();
 };
 
-const playNotification = () => {
+const playNotification = async () => {
   const settings = JSON.parse(localStorage.getItem('nexus_settings') || '{}');
   if (settings.sound === false) return;
 
   try {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    await ctx.resume();
     const oscillator = ctx.createOscillator();
     oscillator.type = 'sine';
     oscillator.frequency.value = 440;

--- a/public/js/dm.js
+++ b/public/js/dm.js
@@ -222,9 +222,13 @@ const updateRecipientStatus = (isOnline) => {
   recipientStatus.textContent = isOnline ? 'نشط الآن' : 'غير متصل';
 };
 
-const playNotification = () => {
+const playNotification = async () => {
+  const settings = JSON.parse(localStorage.getItem('nexus_settings') || '{}');
+  if (settings.sound === false) return;
+
   try {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    await ctx.resume();
     const oscillator = ctx.createOscillator();
     oscillator.type = 'sine';
     oscillator.frequency.value = 440;


### PR DESCRIPTION
## Summary
- resume AudioContext before playing notification tones in chat and DM scripts
- respect sound setting when playing DM notifications

## Testing
- `npm install` *(fails: synckit@0.11.9 not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f90575ef48323be2af27ddd8f70ba